### PR TITLE
ATDS: add AOT validation

### DIFF
--- a/format/aac/aac.go
+++ b/format/aac/aac.go
@@ -30,6 +30,9 @@ func (self *Muxer) WriteHeader(streams []av.CodecData) (err error) {
 		return
 	}
 	self.config = streams[0].(aacparser.CodecData).Config
+	if self.config.ObjectType > aacparser.AOT_AAC_LTP {
+		err = fmt.Errorf("aac: AOT %d is not allowed in ADTS", self.config.ObjectType)
+	}
 	return
 }
 


### PR DESCRIPTION
This pull request adds validation of AOT before writing ADTS stream. Same validation exists in FFmpeg and required by ISO 14496-3 and common sense (can't fit nothing greater than 3 into 2 bits field). 

I was hit by absence of this validation when trying to write AOT_SBR stream. Because of a field overflow AOT value was set to AOT_LTP. Although most client were able to consume that stream some of them were failing to decode and crashing.

<hr/>

MPEG 4 ADTS frame can not have AOT value greater than AAC_LTP.

For HE AAC (both v1 and v2) AOT should be set to AAC_LC. Clients are
supposed to use implicit SBR signaling to detect presence of SBR.

Ref:

https://github.com/FFmpeg/FFmpeg/blob/master/libavformat/adtsenc.c#L65
https://developer.apple.com/library/content/technotes/tn2236/_index.html