### PR TITLE
Fixed build failure

### DIFF
--- a/examples/http_flv_and_rtmp_server/main.go
+++ b/examples/http_flv_and_rtmp_server/main.go
@@ -3,7 +3,6 @@ package main
 import (
 	"sync"
 	"io"
-	"time"
 	"net/http"
 	"github.com/nareix/joy4/format"
 	"github.com/nareix/joy4/av/avutil"


### PR DESCRIPTION
Fixed:
```
./main.go:6: imported and not used: "time"
```