### PR TITLE
Bug in reading TS files

### DIFF
--- a/format/ts/tsio/tsio.go
+++ b/format/ts/tsio/tsio.go
@@ -193,7 +193,7 @@ func (self PMT) parseDescs(b []byte) (descs []Descriptor, err error) {
 			desc.Tag = b[n]
 			desc.Data = make([]byte, b[n+1])
 			n += 2
-			if n+len(desc.Data) < len(b) {
+			if n+len(desc.Data) <= len(b) {
 				copy(desc.Data, b[n:])
 				descs = append(descs, desc)
 				n += len(desc.Data)


### PR DESCRIPTION
Seems that small fix helps to read mpegts files.

How to reproduce the bug it seems to fix:
1. Pick any videofile in any format (I used mkv with h264 codec stream)
2. Convert it into mpegts:
`ffmpeg -i video.mkv -codec copy -f mpegts video.ts`
3. Use the following code to check
```golang
package main

import (
    "github.com/nareix/joy4/format/ts"
    "os"
    "log"
)

func main() {
    file, err := os.Open("/home/user/video.ts")
    if err != nil {
        log.Fatalln(err)
    }
    demux := ts.NewDemuxer(file)
    
    streams, err := demux.Streams()
    if err != nil {
        fmt.Printf("error getting streams: %s\n", err)
        os.Exit(1)
    }
}
```
It should throw an error: "error getting streams: invalid PMT"