### PR TITLE
Fix write trailer bug

### DIFF
--- a/av/avutil/avutil.go
+++ b/av/avutil/avutil.go
@@ -300,11 +300,12 @@ func CopyFile(dst av.Muxer, src av.Demuxer) (err error) {
 		return
 	}
 	if err = CopyPackets(dst, src); err != nil {
-		return
+		if err != io.EOF {
+			return
+		}
 	}
 	if err = dst.WriteTrailer(); err != nil {
 		return
 	}
 	return
 }
-


### PR DESCRIPTION
CopyPackets returns io.EOF if we get to the end of the stream (via default assignment to `err`), so we should explicitly check for io.EOF in CopyFile.  Otherwise we'll never get to WriteTrailer.