### PR TITLE
Fix panic in ReadPanic when no streams

### DIFF
--- a/format/mp4/demuxer.go
+++ b/format/mp4/demuxer.go
@@ -1,17 +1,19 @@
 package mp4
 
 import (
-	"time"
+	"errors"
 	"fmt"
+	"io"
+	"time"
+
 	"github.com/nareix/joy4/av"
 	"github.com/nareix/joy4/codec/aacparser"
 	"github.com/nareix/joy4/codec/h264parser"
 	"github.com/nareix/joy4/format/mp4/mp4io"
-	"io"
 )
 
 type Demuxer struct {
-	r io.ReadSeeker
+	r         io.ReadSeeker
 	streams   []*Stream
 	movieAtom *mp4io.Movie
 }
@@ -124,7 +126,7 @@ func (self *Stream) setSampleIndex(index int) (err error) {
 	}
 
 	if self.sample.SampleSize.SampleSize != 0 {
-		self.sampleOffsetInChunk = int64(self.sampleIndexInChunk)*int64(self.sample.SampleSize.SampleSize)
+		self.sampleOffsetInChunk = int64(self.sampleIndexInChunk) * int64(self.sample.SampleSize.SampleSize)
 	} else {
 		if index >= len(self.sample.SampleSize.Entries) {
 			err = fmt.Errorf("mp4: stream[%d]: sample index out of range", self.idx)
@@ -145,12 +147,12 @@ func (self *Stream) setSampleIndex(index int) (err error) {
 		n := int(entry.Count)
 		if index >= start && index < start+n {
 			self.sampleIndexInSttsEntry = index - start
-			self.dts += int64(index-start)*int64(entry.Duration)
+			self.dts += int64(index-start) * int64(entry.Duration)
 			found = true
 			break
 		}
 		start += n
-		self.dts += int64(n)*int64(entry.Duration)
+		self.dts += int64(n) * int64(entry.Duration)
 		self.sttsEntryIndex++
 	}
 	if !found {
@@ -299,6 +301,10 @@ func (self *Demuxer) ReadPacket() (pkt av.Packet, err error) {
 	if err = self.probe(); err != nil {
 		return
 	}
+	if len(self.streams) == 0 {
+		err = errors.New("mp4: no streams available while trying to read a packet")
+		return
+	}
 
 	var chosen *Stream
 	var chosenidx int
@@ -430,7 +436,7 @@ func (self *Stream) timeToSampleIndex(tm time.Duration) int {
 		entries := self.sample.SyncSample.Entries
 		for i := len(entries) - 1; i >= 0; i-- {
 			if entries[i]-1 < uint32(targetIndex) {
-				targetIndex = int(entries[i]-1)
+				targetIndex = int(entries[i] - 1)
 				break
 			}
 		}


### PR DESCRIPTION
mp4.Demuxer.ReadPacket panics if there's no streams. This change makes it return an error instead.