### PR TITLE
h264parser: Remove Emulation Prevention Bytes (in ParseSPS)

### DIFF
--- a/codec/h264parser/parser.go
+++ b/codec/h264parser/parser.go
@@ -1,3 +1,4 @@
+
 package h264parser
 
 import (

--- a/codec/h264parser/parser.go
+++ b/codec/h264parser/parser.go
@@ -306,7 +306,36 @@ type SPSInfo struct {
 	Height uint
 }
 
+
+func cleanupEmulationPrevention(data []byte) (dataOut []byte, err error) {
+	dataOut = make([]byte, len(data))
+	var rdIdx, wrIdx int
+
+	for ; rdIdx<len(data); rdIdx++ {
+		// Read one byte
+		dataOut[wrIdx] = data[rdIdx]
+		// Check if the next 32 bits match 0x00000300, 0x00000301, 0x00000302, 0x00000303
+		if data[rdIdx] == 0 && rdIdx+3 < len(data) {
+			if data[rdIdx+1] == 0 && data[rdIdx+2] == 3 && (data[rdIdx+3] >= 0 && data[rdIdx+3] < 4) {
+				// Copy byte at rdIdx+1 (0x00)
+				rdIdx++
+				wrIdx++
+				dataOut[wrIdx] = data[rdIdx]
+				// Skip byte at rdIdx+2 (0x03)
+				rdIdx++
+			}
+		}
+		wrIdx++
+	}
+	return dataOut, nil
+}
+
 func ParseSPS(data []byte) (self SPSInfo, err error) {
+	data, err = cleanupEmulationPrevention(data)
+	if err != nil {
+		return
+	}
+
 	r := &bits.GolombBitReader{R: bytes.NewReader(data)}
 
 	if _, err = r.ReadBits(8); err != nil {

--- a/codec/h264parser/parser.go
+++ b/codec/h264parser/parser.go
@@ -1,4 +1,3 @@
-
 package h264parser
 
 import (
@@ -307,7 +306,7 @@ type SPSInfo struct {
 }
 
 
-func cleanupEmulationPrevention(data []byte) (dataOut []byte, err error) {
+func cleanupEmulationPrevention(data []byte) (dataOut []byte) {
 	dataOut = make([]byte, len(data))
 	var rdIdx, wrIdx int
 
@@ -327,14 +326,11 @@ func cleanupEmulationPrevention(data []byte) (dataOut []byte, err error) {
 		}
 		wrIdx++
 	}
-	return dataOut, nil
+	return dataOut
 }
 
 func ParseSPS(data []byte) (self SPSInfo, err error) {
-	data, err = cleanupEmulationPrevention(data)
-	if err != nil {
-		return
-	}
+	data = cleanupEmulationPrevention(data)
 
 	r := &bits.GolombBitReader{R: bytes.NewReader(data)}
 


### PR DESCRIPTION
Emulation Prevention Bytes are not removed from the bitstream, which can lead to incorrect parsing of the SPS.

The cleanupEmulationPrevention() function read the whole SPS pretty much byte-by-byte looking for EPBs. This is not a great method in terms of performance, but SPS are supposed to be quite short so the impact on performance is negligible.