### PR TITLE
use a 10mb chunk size

### DIFF
--- a/format/rtmp/rtmp.go
+++ b/format/rtmp/rtmp.go
@@ -353,7 +353,7 @@ var CodecTypes = flv.CodecTypes
 
 func (self *Conn) writeBasicConf() (err error) {
 	// > SetChunkSize
-	if err = self.writeSetChunkSize(1024 * 1024 * 128); err != nil {
+	if err = self.writeSetChunkSize(1024 * 1024 * 10); err != nil {
 		return
 	}
 	// > WindowAckSize


### PR DESCRIPTION
nginx-rtmp in its push mode doesn't play very nicely with joy4. I believe this to be because [joy4 signals its chunk size as 128mb](https://github.com/nareix/joy4/blob/master/format/rtmp/rtmp.go#L356), which exceeds the 10mb limit [hardcoded in nginx-rtmp](https://github.com/arut/nginx-rtmp-module/blob/master/ngx_rtmp.h#L138); nginx-rtmp [shuts down the connection in response](https://github.com/arut/nginx-rtmp-module/blob/master/ngx_rtmp_handler.c#L824).

I don't know the full implications of this change, but here's @j0sh's comment from an internal Livepeer repo:

> RTMP chunks are rarely larger than one frame (and can actually be interleaved with audio, eg by emitting a chunk per NALU; this in itself causes problems with some RTMP implementations).
>
> The only potential issue I can think of is with really high bit rate content, eg 4K intra, paired with a RTMP implementation that doesn't actually chunk its frames (which is admittedly most of them). The size of a chunk (frame) could exceed 10MB in that case. Technically the protocol is supposed to renegotiate the chunk size if that happens, but most implementations aren't sophisticated enough to accommodate this.
>
> Short of actually checking the frame sizes of such content myself, I'd say it's safe for now.